### PR TITLE
Fix #412 Core: Test: NEP6WalletTest: Improve address verification testing

### DIFF
--- a/src/NeoSharp.Core/Wallet/Helpers/Extensions.cs
+++ b/src/NeoSharp.Core/Wallet/Helpers/Extensions.cs
@@ -29,24 +29,23 @@ namespace NeoSharp.Core.Wallet.Helpers
         public static bool IsValidPrivateKey(this byte[] privateKey)
         {
             //if data.LengthIsCorrect AND data.FirstByteIsCorrect AND data.LastByteIsCorrect
-            var isValid = true;
 
             if (privateKey.Length != 34)
             {
-                isValid = false;
+                return false;
             }
 
             if (privateKey[0] != 0x80)
             {
-                isValid = false;
+                return false;
             }
 
             if (privateKey[33] != 0x01)
             {
-                isValid = false;
+                return false;
             }
 
-            return isValid;
+            return true;
         }
 
         public static void ValidateAccount(this IWalletAccount account)

--- a/src/NeoSharp.Core/Wallet/Helpers/WalletHelper.cs
+++ b/src/NeoSharp.Core/Wallet/Helpers/WalletHelper.cs
@@ -191,17 +191,15 @@ namespace NeoSharp.Core.Wallet.Helpers
 
             var privateKeyByteArray = Crypto.Default.Base58CheckDecode(internalWif);
 
-            if (privateKeyByteArray.IsValidPrivateKey())
-            {
-                var privateKey = new byte[32];
-                Buffer.BlockCopy(privateKeyByteArray, 1, privateKey, 0, privateKey.Length);
-                Array.Clear(privateKeyByteArray, 0, privateKeyByteArray.Length);
-                return privateKey;
-            }
-            else
+            if (!privateKeyByteArray.IsValidPrivateKey())
             {
                 throw new FormatException();
             }
+            
+            var privateKey = new byte[32];
+            Buffer.BlockCopy(privateKeyByteArray, 1, privateKey, 0, privateKey.Length);
+            Array.Clear(privateKeyByteArray, 0, privateKeyByteArray.Length);
+            return privateKey;
         }
 
         #region Private Methods

--- a/test/NeoSharp.Core.Test/SmartContracts/UtContractFactory.cs
+++ b/test/NeoSharp.Core.Test/SmartContracts/UtContractFactory.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NeoSharp.Core.Cryptography;
+using NeoSharp.Core.SmartContract;
+using NeoSharp.Cryptography;
+using NeoSharp.TestHelpers;
+using NeoSharp.Types;
+
+namespace NeoSharp.Core.Test.SmartContracts
+{
+    [TestClass]
+    public class UtContractFactory : TestBase
+    {
+        [TestMethod]
+        public void TestCreateSinglePublicKeyRedeemContract()
+        {
+            var privateKey = new byte[]
+            {
+                103, 53, 97, 56, 98, 18, 129, 236, 104, 172, 110, 254, 31, 5, 142, 188, 116, 114, 216, 54, 247, 77, 151,
+                243, 131, 155, 198, 39, 22, 111, 56, 126
+            };
+
+            var publicKey = Crypto.Default.ComputePublicKey(privateKey, true);
+            var publicKeyInEcPoint = new ECPoint(publicKey);
+
+            var result = ContractFactory.CreateSinglePublicKeyRedeemContract(publicKeyInEcPoint);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Parameters.Length);
+            Assert.AreEqual(ContractParameterType.Signature, result.Parameters[0]);
+            Assert.AreEqual(ContractParameterType.Void, result.ReturnType);
+            Assert.AreEqual(UInt160.Parse("0x0d7c041c584acea51d66f1e9bf144477ad6dca25"), result.ScriptHash);
+        }
+    }
+}

--- a/test/NeoSharp.Core.Test/Wallet/NEP6WalletTest.cs
+++ b/test/NeoSharp.Core.Test/Wallet/NEP6WalletTest.cs
@@ -62,10 +62,10 @@ namespace NeoSharp.Core.Wallet.Test
                 .Setup(x => x.SerializeObject(It.Is<NEP6Wallet>(wallet => wallet.Name == expectedWalletName && wallet.Version == expetectedWalletVersion)))
                 .Returns(expectedNep6WalletSerialized);
 
-            var mockWalletManager = AutoMockContainer.Create<Nep6WalletManager>();
+            var testee = AutoMockContainer.Create<Nep6WalletManager>();
 
-            mockWalletManager.CreateWallet(expectedFileName);
-            Assert.IsNotNull(mockWalletManager.Wallet);
+            testee.CreateWallet(expectedFileName);
+            Assert.IsNotNull(testee.Wallet);
             fileWrapper.Verify(x => x.WriteToFile(expectedNep6WalletSerialized, expectedFileName));
         }
 
@@ -78,9 +78,9 @@ namespace NeoSharp.Core.Wallet.Test
             var fileWrapper = AutoMockContainer.GetMock<IFileWrapper>();
             fileWrapper.Setup(x => x.Exists(expectedFileName)).Returns(true);
 
-            var mockWalletManager = AutoMockContainer.Create<Nep6WalletManager>();
+            var testee = AutoMockContainer.Create<Nep6WalletManager>();
 
-            mockWalletManager.CreateWallet(expectedFileName);
+            testee.CreateWallet(expectedFileName);
         }
 
         [TestMethod]
@@ -98,9 +98,9 @@ namespace NeoSharp.Core.Wallet.Test
                 .Setup(x => x.SerializeObject(It.Is<NEP6Wallet>(wallet => wallet.Name == expectedWalletName && wallet.Version == expetectedWalletVersion)))
                 .Returns(String.Empty);
 
-            var mockWalletManager = AutoMockContainer.Create<Nep6WalletManager>();
+            var testee = AutoMockContainer.Create<Nep6WalletManager>();
 
-            mockWalletManager.CreateWallet(expectedFileName);
+            testee.CreateWallet(expectedFileName);
         }
 
         #endregion
@@ -212,14 +212,14 @@ namespace NeoSharp.Core.Wallet.Test
         [ExpectedException(typeof(WalletNotOpenException))]
         public void TestGetAccountPublicKeyWalletIsNotOpened()
         {
-            var mockWalletManager = GetAWalletManagerWithoutAnWallet();
+            var testee = GetAWalletManagerWithoutAnWallet();
             // Act
-            IWalletAccount walletAccount = mockWalletManager.ImportWif("KxLNhtdXXqaYUW1DKBc1XYQLxhouxXPLgQhR8kk7SYG3ajjR8M8a", _defaultPassword);
+            IWalletAccount walletAccount = testee.ImportWif("KxLNhtdXXqaYUW1DKBc1XYQLxhouxXPLgQhR8kk7SYG3ajjR8M8a", _defaultPassword);
             byte[] privateKey = GetPrivateKeyFromWIF("KxLNhtdXXqaYUW1DKBc1XYQLxhouxXPLgQhR8kk7SYG3ajjR8M8a");
             ECPoint publicKey = new ECPoint(Crypto.Default.ComputePublicKey(privateKey, true));
 
-            mockWalletManager = new Nep6WalletManager(new FileWrapper(), new JsonConverterWrapper());
-            IWalletAccount walletAccount2 = mockWalletManager.GetAccount(publicKey);
+            testee = new Nep6WalletManager(new FileWrapper(), new JsonConverterWrapper());
+            IWalletAccount walletAccount2 = testee.GetAccount(publicKey);
         }
 
         [TestMethod]
@@ -235,8 +235,8 @@ namespace NeoSharp.Core.Wallet.Test
             IWalletAccount walletAccount2 = mockWalletManager.GetAccount(publicKey);
 
             Assert.IsNotNull(walletAccount);
-            //TODO #412: Improve address verification testing
-            //Assert.IsFalse(String.IsNullOrWhiteSpace(walletAccount.Address));
+
+            Assert.AreEqual("AdYJeaHepN3jmdUduBLWPESqwQ9QYQCFi7", walletAccount.Address);
         }
 
         #endregion
@@ -279,13 +279,13 @@ namespace NeoSharp.Core.Wallet.Test
         [ExpectedException(typeof(WalletNotOpenException))]
         public void TestDeleteAccountWalletIsNotOpened()
         {
-            var mockWalletManager = GetAWalletManagerWithoutAnWallet();
-            IWalletAccount walletAccount = mockWalletManager.CreateAndAddAccount(_defaultPassword);
+            var testee = GetAWalletManagerWithoutAnWallet();
+            IWalletAccount walletAccount = testee.CreateAndAddAccount(_defaultPassword);
 
-            Assert.IsTrue(mockWalletManager.Wallet.Accounts.ToList().Count == 1);
+            Assert.IsTrue(testee.Wallet.Accounts.ToList().Count == 1);
 
-            mockWalletManager = new Nep6WalletManager(new FileWrapper(), new JsonConverterWrapper());
-            mockWalletManager.DeleteAccount(walletAccount.Contract.ScriptHash);
+            testee = new Nep6WalletManager(new FileWrapper(), new JsonConverterWrapper());
+            testee.DeleteAccount(walletAccount.Contract.ScriptHash);
         }
 
         [TestMethod]
@@ -315,9 +315,7 @@ namespace NeoSharp.Core.Wallet.Test
             // Assert
             Assert.IsNotNull(walletAccount2);
             Assert.AreEqual(walletAccount1.ScriptHash, walletAccount2.ScriptHash);
-
-            //TODO #412: Check & improve address verification testing
-            //Assert.IsFalse(String.IsNullOrEmpty(walletAccount2.Address));
+            Assert.AreEqual(walletAccount1.Address, walletAccount2.Address);
 
             Assert.IsTrue(mockWalletManager.Wallet.Accounts.Length == 1);
         }
@@ -346,12 +344,12 @@ namespace NeoSharp.Core.Wallet.Test
         [ExpectedException(typeof(WalletNotOpenException))]
         public void TestImportScriptHashWalletIsNotOpened()
         {
-            var mockWalletManager = GetAWalletManagerWithoutAnWallet();
+            var testee = GetAWalletManagerWithoutAnWallet();
             // Act
-            NEP6Account walletAccount1 = (NEP6Account)mockWalletManager.CreateAndAddAccount(_defaultPassword);
+            NEP6Account walletAccount1 = (NEP6Account)testee.CreateAndAddAccount(_defaultPassword);
 
-            mockWalletManager = new Nep6WalletManager(new FileWrapper(), new JsonConverterWrapper());
-            NEP6Account walletAccount2 = (NEP6Account)mockWalletManager.ImportScriptHash(walletAccount1.ScriptHash);
+            testee = new Nep6WalletManager(new FileWrapper(), new JsonConverterWrapper());
+            NEP6Account walletAccount2 = (NEP6Account)testee.ImportScriptHash(walletAccount1.ScriptHash);
         }
 
         #endregion

--- a/test/NeoSharp.Core.Test/Wallet/UtExtensions.cs
+++ b/test/NeoSharp.Core.Test/Wallet/UtExtensions.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NeoSharp.Core.Wallet.Helpers;
+using NeoSharp.TestHelpers;
+
+namespace NeoSharp.Core.Wallet.Test
+{
+    [TestClass]
+    public class UtExtensions : TestBase
+    {
+
+        [TestMethod]
+        public void TestIsValidPrivateKeyTooShort()
+        {
+            var p = new byte[] { 128, 33, 68, 4, 111, 111, 43, 161, 201, 123, 240, 182, 240, 48, 97, 165, 233, 223, 133, 20, 106, 12, 245, 240, 46, 69, 25, 1, 34, 115, 30, 37, 224 };
+            var result = p.IsValidPrivateKey();
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void TestIsValidPrivateKeyTooLong()
+        {
+            var p = new byte[] { 128, 33, 68, 4, 111, 111, 43, 161, 201, 123, 240, 182, 240, 48, 97, 165, 233, 223, 133, 20, 106, 12, 245, 240, 46, 69, 25, 1, 34, 115, 30, 37, 224, 1, 1 };
+            var result = p.IsValidPrivateKey();
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void TestIsValidPrivateKeyNotStartingWith128()
+        {
+            var p = new byte[] { 127, 33, 68, 4, 111, 111, 43, 161, 201, 123, 240, 182, 240, 48, 97, 165, 233, 223, 133, 20, 106, 12, 245, 240, 46, 69, 25, 1, 34, 115, 30, 37, 224, 1 };
+            var result = p.IsValidPrivateKey();
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void TestIsValidPrivateKeyNotEndingWith1()
+        {
+            var p = new byte[] { 128, 33, 68, 4, 111, 111, 43, 161, 201, 123, 240, 182, 240, 48, 97, 165, 233, 223, 133, 20, 106, 12, 245, 240, 46, 69, 25, 1, 34, 115, 30, 37, 224, 2 };
+            var result = p.IsValidPrivateKey();
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void TestIsValidPrivateKey()
+        {
+            var p = new byte[] { 128, 33, 68, 4, 111, 111, 43, 161, 201, 123, 240, 182, 240, 48, 97, 165, 233, 223, 133, 20, 106, 12, 245, 240, 46, 69, 25, 1, 34, 115, 30, 37, 224, 1 };
+            var result = p.IsValidPrivateKey();
+            Assert.IsTrue(result);
+        }
+
+    }
+}

--- a/test/NeoSharp.Core.Test/Wallet/UtWalletHelper.cs
+++ b/test/NeoSharp.Core.Test/Wallet/UtWalletHelper.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NeoSharp.Core.Wallet.Helpers;
+using NeoSharp.Cryptography;
+using NeoSharp.TestHelpers;
+
+namespace NeoSharp.Core.Wallet.Test
+{
+    [TestClass]
+    public class UtWalletHelper : TestBase
+    {
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void TestGetPrivateKeyFromWIFNull()
+        {
+            var testee = new WalletHelper();
+            testee.GetPrivateKeyFromWIF(null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void TestGetPrivateKeyFromWIFInvalidPrivateKey()
+        {
+            var invalidWif = Crypto.Default.Base58CheckEncode(new byte[] { 127, 33, 68, 4, 111, 111, 43, 161, 201, 123, 240, 182, 240, 48, 97, 165, 233, 223, 133, 20, 106, 12, 245, 240, 46, 69, 25, 1, 34, 115, 30, 37, 224, 1 });
+            var testee = new WalletHelper();
+            testee.GetPrivateKeyFromWIF(invalidWif);
+        }
+
+        [TestMethod]
+        public void TestGetPrivateKeyFromWIF()
+        {
+            var wif = "KxLNhtdXXqaYUW1DKBc1XYQLxhouxXPLgQhR8kk7SYG3ajjR8M8a";
+            var testee = new WalletHelper();
+            var result = testee.GetPrivateKeyFromWIF(wif);
+            var expected =  new byte[] { 33, 68, 4, 111, 111, 43, 161, 201, 123, 240, 182, 240, 48, 97, 165, 233, 223, 133, 20, 106, 12, 245, 240, 46, 69, 25, 1, 34, 115, 30, 37, 224 };
+            CollectionAssert.AreEqual(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Fix #412 

I didn't improve the Nep6WalletManager tests, but I created many methods involving the Wallet address composition on other classes